### PR TITLE
Use all configuration options when configuring a strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+## 0.2.0
+
+* Use all configuration options when configuring a strategy instead of 
+  only client_id, client_secret, and specific client_options.
+
+## 0.1.0
+
+* Allow omniauth to be configured through a centralized file on the server.
+

--- a/README.md
+++ b/README.md
@@ -13,14 +13,22 @@ source control or the environment for the user running the application server.
 
 ## Configuration
 
+A configuration contains details about applications and strategies which
+use omniauth. Applications are top level keys (e.g. nucats_assist, nitro) 
+with the exception of the 'defaults'. The 'defaults' top level key is used to 
+keep global options for strategies. When a strategy is configured on a per  
+application level, the default options for that strategy are inherited first
+and the application specific strategy options are applied on top of them.
+
 ```
 # /etc/nubic/omniauth/local.yml
 
 defaults:
   nucats_membership:
-    site: http://membership-staging.nubic.northwestern.edu
-    authorize_url: /auth
-    token_url: /token
+    client_options:
+      site: http://membership-staging.nubic.northwestern.edu
+      authorize_url: /auth
+      token_url: /token
 nucats_assist:
   nucats_membership:
     client_id: abc123
@@ -31,7 +39,7 @@ nucats_assist:
 nitro:
   nucats_membership:
     client_id: xyz987
-    client_secret:ufw654
+    client_secret: ufw654
 ```
 
 ## Rack
@@ -40,7 +48,7 @@ nitro:
 # server.ru
 
 OmniauthConfigure.configure {
-  app :example
+  app :nucats_assist
   strategies :nucats_membership
   central '/etc/nubic/omniauth/local.yml'
 }
@@ -54,7 +62,7 @@ OmniauthConfigure::Rack.use_in(self)
 # config/environments/development.rb
 
 OmniAuthConfigure.configure {
-  app :example
+  app :nucats_assist
   strategies :nucats_membership
   central '/etc/nubic/omniauth/local.yml'
 }

--- a/lib/omniauth_configure/central_parameters.rb
+++ b/lib/omniauth_configure/central_parameters.rb
@@ -1,5 +1,6 @@
 # -*- encoding : utf-8 -*-
 require 'yaml'
+require 'active_support'
 
 module OmniAuthConfigure
   class CentralParameters
@@ -23,9 +24,9 @@ module OmniAuthConfigure
       unless entries.key?(app)
         entries[app] = {}
         entries[app][provider] = 
-            {}.merge((raw_values[:default] || {})[provider] || {}).
-            merge((raw_values[:defaults] || {})[provider] || {}).
-            merge((raw_values[app] || {})[provider] || {})
+            {}.deep_merge((raw_values[:default] || {})[provider] || {}).
+            deep_merge((raw_values[:defaults] || {})[provider] || {}).
+            deep_merge((raw_values[app] || {})[provider] || {})
       end
       entries[app][provider]
     end

--- a/lib/omniauth_configure/rack.rb
+++ b/lib/omniauth_configure/rack.rb
@@ -23,19 +23,11 @@ module OmniAuthConfigure::Rack
 
       p = effective_configuration.parameters_for(app, klass)
 
-      middleware.args [:client_id, :client_secret]
+      arg_keys = p.keys.sort
 
-      cid = p[:client_id]
-      cs  = p[:client_secret]
-      s   = p[:site]
-      au  = p[:authorize_url]
-      tu  = p[:token_url]
+      middleware.args arg_keys
 
-      args = [cid, cs]
-      if s || au || tu
-        middleware.args [:client_id, :client_secret, :client_options]
-        args << {:site => s, :authorize_url => au, :token_url => tu }
-      end
+      args = p.values_at(*arg_keys)
       args << {} # Last argument to provider strategy is empty hash
 
       builder.use middleware, *args, &block

--- a/omniauth_configure.gemspec
+++ b/omniauth_configure.gemspec
@@ -16,5 +16,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'omniauth', '~> 1.2'
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rake'
+  s.add_runtime_dependency 'activesupport'
 end
 

--- a/spec/omniauth_configure/configuration_spec.rb
+++ b/spec/omniauth_configure/configuration_spec.rb
@@ -22,7 +22,7 @@ describe OmniAuthConfigure::Configuration do
     end
 
     it 'aquires the default parameters' do
-      expect(northwestern[:site]).to eq('http://northwestern.edu')
+      expect(northwestern[:client_options][:site]).to eq('http://northwestern.edu')
     end
 
     it 'aquires the parameters' do
@@ -31,7 +31,7 @@ describe OmniAuthConfigure::Configuration do
     end
 
     it 'aquires the overridden parameters' do
-      expect(northwestern[:token_url]).to eq('/override/token')
+      expect(northwestern[:client_options][:token_url]).to eq('/override/token')
     end
   end
 

--- a/spec/omniauth_configure/rack_spec.rb
+++ b/spec/omniauth_configure/rack_spec.rb
@@ -23,7 +23,7 @@ describe OmniAuthConfigure::Rack do
 
       OmniAuthConfigure::Rack.use_in(builder)
       expect(builder.uses[0].first).to eq(OmniAuth::Strategies::Northwestern)
-      expect(builder.uses[0].first.args).to eq([:client_id, :client_secret, :client_options])
+      expect(builder.uses[0].first.args).to eq([:client_id, :client_options, :client_secret])
 
       expect(builder.uses[1].first).to eq(OmniAuth::Strategies::Facebook)
       expect(builder.uses[1].first.args).to eq([:client_id, :client_secret])

--- a/spec/omniauth_configure/test_configuration.yml
+++ b/spec/omniauth_configure/test_configuration.yml
@@ -1,13 +1,15 @@
 defaults:
   northwestern:
-    site: http://northwestern.edu
-    authorize_url: /oauth/auth
-    token_url: /oauth/token
+    client_options:
+      site: http://northwestern.edu
+      authorize_url: /oauth/auth
+      token_url: /oauth/token
 patient_tracker:
   northwestern:
     client_id: c1980
     client_secret: kareem
-    token_url: /override/token
+    client_options:
+      token_url: /override/token
   facebook:
     client_id: c1995
     client_secret: seagal


### PR DESCRIPTION
Only a subset of configuration options is currently used when setting up strategy. This will allow any options to be passed when setting up a provider.
